### PR TITLE
Create Team service layer

### DIFF
--- a/HoopInsightsAPI/Models/TeamDto.cs
+++ b/HoopInsightsAPI/Models/TeamDto.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace HoopInsightsAPI.Models;
 
 public class TeamDto

--- a/HoopInsightsAPI/Models/TeamDto.cs
+++ b/HoopInsightsAPI/Models/TeamDto.cs
@@ -9,10 +9,6 @@ public class TeamDto
     public string Division { get; set; }
     public string City { get; set; }
     public string Name { get; set; }
-    
-    [JsonPropertyName("full_name")]
     public string FullName { get; set; }
-    
-    [JsonPropertyName("abbreviation")]
     public string Abbreviation { get; set; }
 }

--- a/HoopInsightsAPI/Program.cs
+++ b/HoopInsightsAPI/Program.cs
@@ -1,3 +1,5 @@
+using HoopInsightsAPI.Services;
+
 namespace HoopInsightsAPI;
 
 public class Program
@@ -5,6 +7,8 @@ public class Program
     public static void Main(string[] args)
     {
         var builder = WebApplication.CreateBuilder(args);
+
+        builder.Services.AddScoped<ITeamService, TeamService>();
 
         // Add services to the container.
 
@@ -17,7 +21,6 @@ public class Program
         app.UseHttpsRedirection();
 
         app.UseAuthorization();
-
 
         app.MapControllers();
 


### PR DESCRIPTION
Removed references for JsonPropertyName because the snake case JSON names that the BDL API sends over is matched to the application's Pascal Case naming convention using JsonSerializerOptions within the TeamService.cs file and setting `PropertyNameCaseInsensitive = true`

Added scoped registration for TeamService and ITeamService within Program.cs

*Note: most of this service layer was set up during the migration to Web API, hence the lack of commit history for the bulk of the configuration*