### PR TITLE
Add ApiKeyForwardingHandler to forward X-BDL-API-Key header

### DIFF
--- a/HoopInsightsAPI/HoopInsightsAPI.csproj
+++ b/HoopInsightsAPI/HoopInsightsAPI.csproj
@@ -8,7 +8,6 @@
 
     <ItemGroup>
       <Folder Include="Controllers\" />
-      <Folder Include="Middleware\" />
     </ItemGroup>
 
 </Project>

--- a/HoopInsightsAPI/Middleware/ApiKeyForwardingHandler.cs
+++ b/HoopInsightsAPI/Middleware/ApiKeyForwardingHandler.cs
@@ -1,0 +1,6 @@
+namespace HoopInsightsAPI.Middleware;
+
+public class ApiKeyForwardingHandler
+{
+    
+}

--- a/HoopInsightsAPI/Middleware/ApiKeyForwardingHandler.cs
+++ b/HoopInsightsAPI/Middleware/ApiKeyForwardingHandler.cs
@@ -1,6 +1,29 @@
 namespace HoopInsightsAPI.Middleware;
 
-public class ApiKeyForwardingHandler
+public class ApiKeyForwardingHandler : DelegatingHandler
 {
-    
+    private readonly IHttpContextAccessor _httpContextAccessor;
+    private const string ApiKeyHeaderName = "X-BDL-API-Key";
+
+    public ApiKeyForwardingHandler(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var headers = _httpContextAccessor.HttpContext?.Request.Headers;
+        if (headers != null && headers.TryGetValue(ApiKeyHeaderName, out var values))
+        {
+            var apiKey = values.ToString();
+            if (!string.IsNullOrWhiteSpace(apiKey))
+            {
+                request.Headers.Remove(ApiKeyHeaderName);
+                request.Headers.Add(ApiKeyHeaderName, apiKey);
+            }
+        }
+
+        return await base.SendAsync(request, cancellationToken);
+    }
 }

--- a/HoopInsightsAPI/Program.cs
+++ b/HoopInsightsAPI/Program.cs
@@ -1,3 +1,4 @@
+using HoopInsightsAPI.Clients;
 using HoopInsightsAPI.Middleware;
 using HoopInsightsAPI.Services;
 
@@ -11,8 +12,16 @@ public class Program
 
         builder.Services.AddScoped<ITeamService, TeamService>();
 
+        // Make IHTTPContextAccessor available and register custom HTTP handler.
         builder.Services.AddHttpContextAccessor();
         builder.Services.AddTransient<ApiKeyForwardingHandler>();
+
+        // Register typed HttpClient and wire up custom handler.
+        builder.Services.AddHttpClient<IBalldontlieClient, BalldontlieClient>(client =>
+        {
+            client.BaseAddress = new Uri("https://api.balldontlie.io/v1/");
+        })
+        .AddHttpMessageHandler<ApiKeyForwardingHandler>();
 
         // Add services to the container.
 

--- a/HoopInsightsAPI/Program.cs
+++ b/HoopInsightsAPI/Program.cs
@@ -1,3 +1,4 @@
+using HoopInsightsAPI.Middleware;
 using HoopInsightsAPI.Services;
 
 namespace HoopInsightsAPI;
@@ -9,6 +10,9 @@ public class Program
         var builder = WebApplication.CreateBuilder(args);
 
         builder.Services.AddScoped<ITeamService, TeamService>();
+
+        builder.Services.AddHttpContextAccessor();
+        builder.Services.AddTransient<ApiKeyForwardingHandler>();
 
         // Add services to the container.
 


### PR DESCRIPTION
- Added api key forwarding handler `ApiKeyForwardingHandler.cs`
    - Extends `DelegatingHandler` for modifying incoming HTTP requests
    - Uses `IHttpContextAccessor` to read the incoming `X-BDL-API-Key` header and copies that header onto every `HttpRequestMessage` before it goes out

- Changed Program.cs to integrate new custom HTTP handler
  - Added`builder.Services.AddHttpContextAccessor();` to enable `IHttpContextAccessor` and `builder.Services.AddTransient<ApiKeyForwardingHandler>();` to register the handler
  - Added `.AddHttpClient<IBalldontlieClient, BalldontlieClient>()` and wired
    `.AddHttpMessageHandler<ApiKeyForwardingHandler>()` so all BalldontlieClient calls automatically carry the header