### PR TITLE
Add TeamService unit testing

### DIFF
--- a/.idea/.idea.HoopInsights/.idea/.gitignore
+++ b/.idea/.idea.HoopInsights/.idea/.gitignore
@@ -1,0 +1,13 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/modules.xml
+/contentModel.xml
+/projectSettingsUpdater.xml
+/.idea.HoopInsights.iml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/HoopInsights.sln.DotSettings.user
+++ b/HoopInsights.sln.DotSettings.user
@@ -1,0 +1,6 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=5e1f9d4d_002D9a9f_002D483f_002Dbfe2_002Dc2a900b8a5c1/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="GetTeamsAsync_WithName_ShouldReturnMappedTeamDto" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
+  &lt;TestAncestor&gt;
+    &lt;TestId&gt;xUnit::8AE23F82-AB41-4C90-94C1-AA50FB5B8CB9::net8.0::HoopInsightsAPI.Tests.Services.TeamServiceTests.GetTeamsAsync_WithName_ShouldReturnMappedTeamDto&lt;/TestId&gt;
+  &lt;/TestAncestor&gt;
+&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/HoopInsightsAPI.Tests/Services/TeamServiceTests.cs
+++ b/HoopInsightsAPI.Tests/Services/TeamServiceTests.cs
@@ -1,6 +1,17 @@
-namespace HoopInsightsAPI.Tests;
+using HoopInsightsAPI.Clients;
+using HoopInsightsAPI.Services;
+using Moq;
+
+namespace HoopInsightsAPI.Tests.Services;
 
 public class TeamServiceTests
 {
-    
+    private readonly Mock<IBalldontlieClient> _clientMock;
+    private readonly TeamService _teamService;
+
+    public TeamServiceTests()
+    {
+        _clientMock = new Mock<IBalldontlieClient>();
+        _teamService = new TeamService(_clientMock.Object);
+    }
 }

--- a/HoopInsightsAPI.Tests/Services/TeamServiceTests.cs
+++ b/HoopInsightsAPI.Tests/Services/TeamServiceTests.cs
@@ -1,0 +1,6 @@
+namespace HoopInsightsAPI.Tests;
+
+public class TeamServiceTests
+{
+    
+}

--- a/HoopInsightsAPI.Tests/Services/TeamServiceTests.cs
+++ b/HoopInsightsAPI.Tests/Services/TeamServiceTests.cs
@@ -1,3 +1,4 @@
+using FluentAssertions;
 using HoopInsightsAPI.Clients;
 using HoopInsightsAPI.Services;
 using Moq;
@@ -13,5 +14,41 @@ public class TeamServiceTests
     {
         _clientMock = new Mock<IBalldontlieClient>();
         _teamService = new TeamService(_clientMock.Object);
+    }
+
+    [Fact]
+    public async Task GetTeamsAsync_WithName_ShouldReturnMappedTeamDto()
+    {
+        // Arrange
+        var jsonResponse = """
+           {
+             "data": [
+               {
+                 "id": 14,
+                 "abbreviation": "MIN",
+                 "city": "Minnesota",
+                 "conference": "West",
+                 "division": "Northwest",
+                 "full_name": "Minnesota Timberwolves",
+                 "name": "Timberwolves"
+               }
+             ]
+           }
+       """;
+        
+        _clientMock
+            .Setup(client => client.GetTeamsJsonAsync("minnesota"))
+            .ReturnsAsync(jsonResponse);
+
+        // Act
+        var teams = await _teamService.GetTeamsAsync("minnesota");
+        
+        // Assert
+        teams.Should().HaveCount(1, because: "the JSON contains exactly one team");
+
+        var team = teams.First();
+        team.FullName.Should().Be("Minnesota Timberwolves", because: "that is the full_name value in the JSON");
+        team.Id.Should().Be(14, because: "the id is 14 in the JSON");
+        team.Abbreviation.Should().Be("MIN", because: "the abbreviation is MIN in the JSON");
     }
 }

--- a/HoopInsightsAPI/Services/TeamService.cs
+++ b/HoopInsightsAPI/Services/TeamService.cs
@@ -9,7 +9,7 @@ public class TeamService : ITeamService
     private readonly IBalldontlieClient _client;
     private readonly JsonSerializerOptions _jsonOptions;
 
-    public TeamService(IBalldontlieClient client, JsonSerializerOptions jsonOptions)
+    public TeamService(IBalldontlieClient client)
     {
         _client = client;
         _jsonOptions = new JsonSerializerOptions


### PR DESCRIPTION
- Added TeamServiceTests class
    - Constructor accepts mock `IBalldontlieClient` to test its logic rather than the wiring of HttpClient
    - Test for `GetTeamsAsync_WithName_ShouldReturnMappedTeamDto` ensures that when client is called to get teams it correctly maps the JSON data to our TeamDto

- Removed unused jsonOptions paramter from TeamService class  
  - Unused parameter caused conflict when building TeamServiceTest constructor so that's how the mistake was picked up on