### PR TITLE
Add back jsonOptions to TeamService

### DIFF
--- a/HoopInsights.sln.DotSettings.user
+++ b/HoopInsights.sln.DotSettings.user
@@ -1,6 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=5e1f9d4d_002D9a9f_002D483f_002Dbfe2_002Dc2a900b8a5c1/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="GetTeamsAsync_WithName_ShouldReturnMappedTeamDto" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;
   &lt;TestAncestor&gt;
-    &lt;TestId&gt;xUnit::8AE23F82-AB41-4C90-94C1-AA50FB5B8CB9::net8.0::HoopInsightsAPI.Tests.Services.TeamServiceTests.GetTeamsAsync_WithName_ShouldReturnMappedTeamDto&lt;/TestId&gt;
+    &lt;TestId&gt;xUnit::8AE23F82-AB41-4C90-94C1-AA50FB5B8CB9::net8.0::HoopInsightsAPI.Tests.Services.TeamServiceTests&lt;/TestId&gt;
   &lt;/TestAncestor&gt;
 &lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/HoopInsightsAPI/Services/TeamService.cs
+++ b/HoopInsightsAPI/Services/TeamService.cs
@@ -7,17 +7,22 @@ namespace HoopInsightsAPI.Services;
 public class TeamService : ITeamService
 {
     private readonly IBalldontlieClient _client;
+    private readonly JsonSerializerOptions _jsonOptions;
 
     public TeamService(IBalldontlieClient client)
     {
         _client = client;
+        _jsonOptions = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        };
     }
     
     public async Task<IEnumerable<TeamDto>> GetTeamsAsync(string? name = null)
     {
         var teamJson = await _client.GetTeamsJsonAsync(name ?? string.Empty);
 
-        var teamResponse = JsonSerializer.Deserialize<TeamsResponseDto>(teamJson)
+        var teamResponse = JsonSerializer.Deserialize<TeamsResponseDto>(teamJson, _jsonOptions)
                            ?? throw new InvalidOperationException("Failed to parse response from teams endpoint.");
 
         return teamResponse.Data;


### PR DESCRIPTION
- Added back jsonOptions which was missing in previous PR
  - Test was failing because of case sensitivity and resulted in no object being mapped at all