### PR TITLE
Add team filtering logic

### DIFF
--- a/HoopInsightsAPI.Tests/Services/TeamServiceTests.cs
+++ b/HoopInsightsAPI.Tests/Services/TeamServiceTests.cs
@@ -37,7 +37,7 @@ public class TeamServiceTests
        """;
         
         _clientMock
-            .Setup(client => client.GetTeamsJsonAsync("minnesota"))
+            .Setup(client => client.GetTeamsJsonAsync())
             .ReturnsAsync(jsonResponse);
 
         // Act

--- a/HoopInsightsAPI/Clients/BalldontlieClient.cs
+++ b/HoopInsightsAPI/Clients/BalldontlieClient.cs
@@ -10,13 +10,9 @@ public class BalldontlieClient : IBalldontlieClient
     {
         _httpClient = httpClient;
     }
-    public async Task<string> GetTeamsJsonAsync(string name = "")
+    public async Task<string> GetTeamsJsonAsync()
     {
-        var url = string.IsNullOrWhiteSpace(name)
-            ? "teams"
-            : $"teams?search={name.NormaliseForFuzzySearch()}";
-        
-        using var response = await _httpClient.GetAsync(url);
+        using var response = await _httpClient.GetAsync("teams");
         response.EnsureSuccessStatusCode();
 
         return await response.Content.ReadAsStringAsync();

--- a/HoopInsightsAPI/Clients/IBalldontlieClient.cs
+++ b/HoopInsightsAPI/Clients/IBalldontlieClient.cs
@@ -2,8 +2,5 @@ namespace HoopInsightsAPI.Clients;
 
 public interface IBalldontlieClient
 {
-    Task<string> GetTeamsJsonAsync(string name = null)
-    {
-        throw new NotImplementedException();
-    }
+    Task<string> GetTeamsJsonAsync();
 }

--- a/HoopInsightsAPI/Services/TeamService.cs
+++ b/HoopInsightsAPI/Services/TeamService.cs
@@ -21,7 +21,7 @@ public class TeamService : ITeamService
     
     public async Task<IEnumerable<TeamDto>> GetTeamsAsync(string? name = null)
     {
-        var teamJson = await _client.GetTeamsJsonAsync(string.Empty);
+        var teamJson = await _client.GetTeamsJsonAsync();
 
         var teamResponse = JsonSerializer.Deserialize<TeamsResponseDto>(teamJson, _jsonOptions)
                            ?? throw new InvalidOperationException("Failed to parse response from teams endpoint.");

--- a/HoopInsightsAPI/Services/TeamService.cs
+++ b/HoopInsightsAPI/Services/TeamService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using HoopInsightsAPI.Clients;
+using HoopInsightsAPI.Extensions;
 using HoopInsightsAPI.Models;
 
 namespace HoopInsightsAPI.Services;
@@ -20,11 +21,21 @@ public class TeamService : ITeamService
     
     public async Task<IEnumerable<TeamDto>> GetTeamsAsync(string? name = null)
     {
-        var teamJson = await _client.GetTeamsJsonAsync(name ?? string.Empty);
+        var teamJson = await _client.GetTeamsJsonAsync(string.Empty);
 
         var teamResponse = JsonSerializer.Deserialize<TeamsResponseDto>(teamJson, _jsonOptions)
                            ?? throw new InvalidOperationException("Failed to parse response from teams endpoint.");
 
-        return teamResponse.Data;
+        var teams = teamResponse.Data;
+
+        if (string.IsNullOrEmpty(name)) return teams;
+        
+        var searchToken = name.NormaliseForFuzzySearch();
+        teams = teams
+            .Where(team =>
+                team.FullName.ToLowerInvariant().Contains(searchToken) || team.Name.ToLowerInvariant().Contains(searchToken))
+            .ToList();
+
+        return teams;
     }
 }


### PR DESCRIPTION
- Added team name filter logic to `TeamService.cs`
  - BalldontlieClient refactored to align client functionality with service handling filtering
  - Tests refactored to align with changes

Filtering logic is not natively handled by BDL API so the application will always fetch a full list from the Teams endpoint and then filter using a partial name provided by the user, so this is executed within the TeamService.