### PR TITLE
Implement TeamController logic

### DIFF
--- a/HoopInsightsAPI/Controllers/TeamController.cs
+++ b/HoopInsightsAPI/Controllers/TeamController.cs
@@ -18,6 +18,10 @@ public class TeamController : ControllerBase
     [HttpGet]
     public async Task<IActionResult> GetTeams([FromQuery]string? name)
     {
-        throw new NotImplementedException();
+        var teams = await _teamService.GetTeamsAsync(name);
+
+        if (!teams.Any()) return NotFound(new { status = 404, error = "No teams found." });
+
+        return Ok(teams);
     }
 }

--- a/HoopInsightsAPI/Middleware/ApiKeyForwardingHandler.cs
+++ b/HoopInsightsAPI/Middleware/ApiKeyForwardingHandler.cs
@@ -20,7 +20,7 @@ public class ApiKeyForwardingHandler : DelegatingHandler
             if (!string.IsNullOrWhiteSpace(apiKey))
             {
                 request.Headers.Remove(ApiKeyHeaderName);
-                request.Headers.Add(ApiKeyHeaderName, apiKey);
+                request.Headers.Add("Authorization", apiKey);
             }
         }
 

--- a/HoopInsightsAPI/Properties/launchSettings.json
+++ b/HoopInsightsAPI/Properties/launchSettings.json
@@ -12,8 +12,7 @@
     "http": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchUrl": "weatherforecast",
+      "launchBrowser": false,
       "applicationUrl": "http://localhost:5014",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -22,8 +21,7 @@
     "https": {
       "commandName": "Project",
       "dotnetRunMessages": true,
-      "launchBrowser": true,
-      "launchUrl": "weatherforecast",
+      "launchBrowser": false,
       "applicationUrl": "https://localhost:7053;http://localhost:5014",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -31,8 +29,7 @@
     },
     "IIS Express": {
       "commandName": "IISExpress",
-      "launchBrowser": true,
-      "launchUrl": "weatherforecast",
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
- Added logic for GetTeams controller method
- Amended header name when API key is forwarded to BDL API to be "Authorization" rather than our custom "X-BDL-API-Key" which was not recognised"
- Disabled default browser launch setting as it's redundant for the application