### PR TITLE
Fix JSON response data

### DIFF
--- a/HoopInsightsAPI.Tests/Services/TeamServiceTests.cs
+++ b/HoopInsightsAPI.Tests/Services/TeamServiceTests.cs
@@ -103,7 +103,7 @@ public class TeamServiceTests
              "data": [
                {
                  "id": 1,
-                 "abbreviation": "BOS",
+                 "abbreviation": "ATL",
                  "city": "Atlanta",
                  "conference": "East",
                  "division": "Southeast",


### PR DESCRIPTION
- Changed incorrect abbreviation for Atlanta Hawks in jsonResponse variable